### PR TITLE
Add Hard restart command

### DIFF
--- a/scripts/streaming/TASLink.py
+++ b/scripts/streaming/TASLink.py
@@ -653,6 +653,15 @@ class CLI(cmd.Cmd):
         self.do_on(data)
         print("The restart process is complete!")
 
+    def do_hard_restart(self, data):
+        """Turns the SNES console off, restarts the current run, and turns the SNES console on"""
+        self.do_off(data)
+        time.sleep(1)
+        self.do_reset(data)
+        time.sleep(1)
+        self.do_on(data)
+        print("The restart process is complete!")
+
     def do_modify_frames(self, data):
         """Modify the initial blank input frames"""
         # print options

--- a/scripts/streaming/TASLink.py
+++ b/scripts/streaming/TASLink.py
@@ -647,9 +647,9 @@ class CLI(cmd.Cmd):
     def do_restart(self, data):
         """Turns the SNES console off, restarts the current run, and turns the SNES console on"""
         self.do_off(data)
-        time.sleep(1)
+        time.sleep(0.2)
         self.do_reset(data)
-        time.sleep(1)
+        time.sleep(0.2)
         self.do_on(data)
         print("The restart process is complete!")
 


### PR DESCRIPTION
Current restart command will reset flash carts like SD2SNES and Everdrive
I figure the best way to resolve this is 2 different command so you can do a hard reset if you need it, but otherwise do a quick one that doesn't reset flash carts