### PR TITLE
Add a single blank frame to the end of the input buffer

### DIFF
--- a/scripts/streaming/TASLink.py
+++ b/scripts/streaming/TASLink.py
@@ -392,6 +392,12 @@ class TASRun(object):
                 buffer[frameno+self.dummyFrames] = command_string
                 frameno += 1
 
+        # add empty frame to end of file to prevent desyncs on last frame
+        working_string = customCommand
+        for bytes in range(bytesPerCommand):
+            working_string += chr(0xFF)
+        buffer.append(working_string)
+
         return buffer
 
 


### PR DESCRIPTION
this is to fix a bug? with the TASLink board as it will hold and continue to send the last frame of input it received, this fixes it by appending a blank frame to the end of input